### PR TITLE
Test Tub Detection (Assuming circular shape)

### DIFF
--- a/pcr/gizzmos.py
+++ b/pcr/gizzmos.py
@@ -47,3 +47,77 @@ class AtalantaModule:
 
     def check_connection(self) -> bool:
         return True
+    
+
+import cv2 as cv
+import numpy as np
+class TestTubeCV:
+    def __init__(self):
+        self.videoCapture = cv.VideoCapture(0, cv.CAP_DSHOW)
+        self.prevCircle = None
+        self.dist = lambda x1, y1, x2, y2: (x1 - x2) ** 2 + (y1 - y2) ** 2
+        self.debug = False
+
+    def predict(self, frame):
+        """
+        Interprets a single frame given to it by the video feed.
+        Preprocesses the image by first converting it to greyscale, performing a median blur, and then utilizing a Hough Transform to generate circles.
+        Of the given Hough circles, will filter out any circles that overlap with already predicted circles.
+        Will get x- and y- corrdinate of each predicted circle's center.
+
+        DISCLAIMER: As of right now, Hough Transform, RANSAC, or some mixture of the two doesn't work the best.
+
+        Args: frame (cv.image): the input image to interpret from and predict on.
+        Returns: pred (list(int, int)): a list of tuples consisting of the x- and y- coordinates of the predicted circles.
+        """
+        pred = []
+
+        # blur image for canny detection (Hough Transform)
+        gray = cv.cvtColor(frame, cv.COLOR_BGR2GRAY)
+        gray = cv.medianBlur(gray, 13)
+        
+        # docstring of HoughCircles: HoughCircles(image, method, dp, minDist[, circles[, param1[, param2[, minRadius[, maxRadius]]]]]) -> circles
+        circles = cv.HoughCircles(gray, cv.HOUGH_GRADIENT, dp=1.0, minDist=10, 
+                                param1 = 60,
+                                param2 = 75,
+                                minRadius = 1, maxRadius = 50)
+        if circles is not None:
+            circles = np.uint16(np.around(circles))
+            chosen = None
+            for i in circles[0, :]:
+                if chosen is None:
+                    chosen = i
+                if self.prevCircle is not None:
+                    if self.dist(chosen[0], chosen[1], self.prevCircle[0], self.prevCircle[1]) <= self.dist(i[0], i[1], self.prevCircle[0], self.prevCircle[1]):
+                        chosen = i
+                cv.circle(frame, (i[0], i[1]), 1, (0, 100, 100), 3)
+                cv.circle(frame, (i[0], i[1]), i[2], (255, 0 , 255), 3)
+            
+                self.prevCircle = chosen
+                pred.append((chosen[0], chosen[1]))
+        
+        
+        cv.imshow("circles", frame)
+        cv.imshow("grayscale", gray)
+        return pred
+
+    def getCircles(self):
+        """
+        Reads in a frame from a birds' eye view video feed, predicts circles, and prints the x- and y- coordinates of the center.
+        Args: None
+        Returns: None
+        """
+        while True:
+            ret, frame = self.videoCapture.read()
+            if not ret:
+                break
+
+            predicted = self.predict(frame)
+            if predicted != []:
+                print(predicted)
+
+            if cv.waitKey(1) == ord('q'):
+                break
+        self.videoCapture.release()
+        cv.destroyAllWindows()
+

--- a/pcr/main.py
+++ b/pcr/main.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
 import os
 import sys
+
+# Add xArm python modules to the PATH
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
 import time
 import json
 import argparse
 from mypy_types import RequestDict
 import logging
-from pcr.gizzmos import AtalantaModule
 
 from xarm.wrapper import XArmAPI
-from gizzmos import CustomGripper, PressureSensor
-
-print('test commit to show something')
+from pcr.gizzmos import CustomGripper, PressureSensor, AtalantaModule
 
 class RunJob():
     SPEED = 50

--- a/pcr/main.py
+++ b/pcr/main.py
@@ -11,6 +11,8 @@ from pcr.gizzmos import AtalantaModule
 from xarm.wrapper import XArmAPI
 from gizzmos import CustomGripper, PressureSensor
 
+print('test commit to show something')
+
 class RunJob():
     SPEED = 50
     ZERO_POS   = [0, 0, 0, 0, 0, 0]


### PR DESCRIPTION
# Description

- How this works
This will take in an image feed, read and preprocess a single frame, and generate predictions of possible circular test tube openings via a Hough transform.
- Limitations
Working Hough Transform has notoriously low accuracy, can't detect plastic tube entrances unless there is a lot of contrast around the border
I suspect overfitting may be at play here since it's extremely conservative in its predictions.
- What doesn't work
Attempted RANSAC for better circle detection - didn't work as well as Hough Transform
Attempted to combine the two, but the resultant model did not yield a better result than just using a Hough Transform.
- Possible Routes
Utilizing a Neural Net-based architecture to identify test tubes via bounding boxes. Maybe YOLOv5 or some other conventional model.
# Testing
- Pictures
<img width="980" alt="image" src="https://user-images.githubusercontent.com/89279052/223298363-9f21bffb-cc1d-4b21-b3a4-b727b7d02fe6.png">

- Screenshots
WIP
- Test cases
WIP